### PR TITLE
Workaround for https://pad.lv/1794991

### DIFF
--- a/templates/train/ml2_conf.ini
+++ b/templates/train/ml2_conf.ini
@@ -59,9 +59,3 @@ enable_security_group = False
 [ml2_sriov]
 supported_pci_vendor_devs = {{ supported_pci_vendor_devs }}
 {% endif -%}
-
-{# NOTE: agent_boot_time deprecated in Stein, removed in Train #}
-{% if 'l2population' in mechanism_drivers %}
-[l2pop]
-agent_boot_time = 1800
-{% endif %}


### PR DESCRIPTION
* Added l2pop option agent_boot_time and set to 10x its default to work
around the issue.  Should help queens/rocky.  Less certain, but may
help stein in some cases.

* Train removes the config option, so copied the queens ml2_conf.ini
template to train, minus the new changes.